### PR TITLE
build: Fixes a typo for a config file

### DIFF
--- a/gbs/module-config.cmake.in
+++ b/gbs/module-config.cmake.in
@@ -44,6 +44,6 @@ endif()
 
 # import targets and reference dependencies
 set(PACKAGE_TARGETS_FILE ${CMAKE_CURRENT_LIST_DIR}/@INSTALL_MODULE_NAME@-targets.cmake)
-if(EXISTS PACKAGE_TARGETS_FILE)
+if(EXISTS ${PACKAGE_TARGETS_FILE})
   include(${PACKAGE_TARGETS_FILE})
 endif()


### PR DESCRIPTION
(cherry picked from commit 22c2b485a03a26e9375cbb0f033d552d7cc79c3e)