### PR TITLE
ci: Downgrade compilers to latest stable releases

### DIFF
--- a/docs/01_install.md
+++ b/docs/01_install.md
@@ -4,7 +4,7 @@
 
 OS               |  Architecture   | Toolchain
 -----------------|-----------------|----------------
-Ubuntu 24.04 LTS | Aarch64, X86_64 | CMake-4, clang-21/libc++, gcc-15/libstdc++
+Ubuntu 24.04 LTS | Aarch64, X86_64 | CMake-4, clang-20/libc++, gcc-14/libstdc++
 
 ## Setup development environment
 

--- a/toolchains/install_gcc.sh
+++ b/toolchains/install_gcc.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-GCC_VERSION=15
+GCC_VERSION=14
 
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get update

--- a/toolchains/install_llvm.sh
+++ b/toolchains/install_llvm.sh
@@ -8,7 +8,7 @@
 set -e
 
 # Supported LLVM version
-LLVM_VERSION=21 
+LLVM_VERSION=20 
 
 # Download
 wget https://apt.llvm.org/llvm.sh


### PR DESCRIPTION
Clang-21 is unstable right now, throwing a lot of linter errors